### PR TITLE
Introduce DB_NAME env var to configure the database name

### DIFF
--- a/nazgul/__init__.py
+++ b/nazgul/__init__.py
@@ -62,6 +62,7 @@ def create_app():
     app.config["DATABASE_URL"] = os.environ.get("DATABASE_URL", "127.0.0.1")
     app.config["DB_USER"] = os.environ.get("DB_USER", "root")
     app.config["DB_PASS"] = os.environ.get("DB_PASS", "")
+    app.config["DB_NAME"] = os.environ.get("DB_NAME", "bouncer")
 
     app.config["AUTH_USERS"] = os.environ.get("AUTH_USERS", "{}")
 

--- a/nazgul/db.py
+++ b/nazgul/db.py
@@ -9,5 +9,6 @@ def get_db():
             host=current_app.config["DATABASE_URL"],
             user=current_app.config["DB_USER"],
             password=current_app.config["DB_PASS"],
+            db=current_app.config["DB_NAME"],
         )
     return g.db


### PR DESCRIPTION
This allows to configure a different database name, e.g. for localdev.